### PR TITLE
fix: `QueryBuilder` and `StatementFactory` should escape values with backticks where appropriate. 

### DIFF
--- a/packages/db/test/CrudTests.ts
+++ b/packages/db/test/CrudTests.ts
@@ -13,7 +13,7 @@ export interface Employee extends Record {
   object?: string;
 }
 
-export class EmployeeTable extends Table<Employee> {
+export class EmployeeTestTable extends Table<Employee> {
   name = 'db_test_employee';
   columns = withRecordColumns<Employee>({
     name: new StringColumn('name'),
@@ -25,13 +25,35 @@ export class EmployeeTable extends Table<Employee> {
   });
 }
 
+export interface ReservedWordTest extends Record {
+  name: string;
+  order?: string;
+  select?: string;
+  join?: string;
+}
+
+export class ReservedWordTestTable extends Table<ReservedWordTest> {
+  name = 'db_test_reserved_word';
+  columns = withRecordColumns<ReservedWordTest>({
+    name: new StringColumn('name'),
+    order: new StringColumn('order'),
+    select: new StringColumn('select'),
+    join: new StringColumn('join'),
+  });
+}
+
 /**
  * Used for testing purposes only.
  *  */
 export const getTestTable = (tableName: string) => {
-  const employeeTable = new EmployeeTable();
+  const employeeTable = new EmployeeTestTable();
   if (employeeTable.name == tableName) {
-    return new EmployeeTable();
+    return new EmployeeTestTable();
+  }
+
+  const reservedWordTestTable = new ReservedWordTestTable();
+  if (reservedWordTestTable.name == tableName) {
+    return new ReservedWordTestTable();
   }
 
   throw new Error(`Cannot find test table: ${tableName}`);
@@ -46,11 +68,13 @@ export const crudTests = (driver: DbDriver, dropTable: (table: Table<any>) => Pr
         await driver.start();
       }
 
-      await driver.getTableManager().loadTable(new EmployeeTable());
+      await driver.getTableManager().loadTable(new EmployeeTestTable());
+      await driver.getTableManager().loadTable(new ReservedWordTestTable());
     });
 
     afterAll(async () => {
-      await dropTable(new EmployeeTable());
+      await dropTable(new EmployeeTestTable());
+      await dropTable(new ReservedWordTestTable());
 
       if (driver.stop) {
         await driver.stop();
@@ -59,7 +83,7 @@ export const crudTests = (driver: DbDriver, dropTable: (table: Table<any>) => Pr
 
     test('Insert', async () => {
       const testEmployee: Omit<Employee, keyof Record> = { name: 'Veronica' };
-      const emplyeeTable: Table<Employee> = new EmployeeTable();
+      const emplyeeTable: Table<Employee> = new EmployeeTestTable();
       const insertedEmployee = await db.insert(emplyeeTable, testEmployee);
       const fetchedEmployee = await db.get(emplyeeTable, { id: insertedEmployee.id });
       expect(fetchedEmployee).toBeTruthy();
@@ -68,7 +92,7 @@ export const crudTests = (driver: DbDriver, dropTable: (table: Table<any>) => Pr
 
     test('Update', async () => {
       const testEmployee: Omit<Employee, keyof Record> = { name: 'Veronica' };
-      const emplyeeTable: Table<Employee> = new EmployeeTable();
+      const emplyeeTable: Table<Employee> = new EmployeeTestTable();
       const insertedEmployee = await db.insert(emplyeeTable, testEmployee);
       const updateCount = await db.update(
         emplyeeTable,
@@ -89,7 +113,7 @@ export const crudTests = (driver: DbDriver, dropTable: (table: Table<any>) => Pr
 
     test('Delete', async () => {
       const testEmployee: Omit<Employee, keyof Record> = { name: 'Veronica' };
-      const emplyeeTable: Table<Employee> = new EmployeeTable();
+      const emplyeeTable: Table<Employee> = new EmployeeTestTable();
       const insertedEmployee = await db.insert(emplyeeTable, testEmployee);
       let fetchedEmployee = await db.get(emplyeeTable, { id: insertedEmployee.id });
       expect(fetchedEmployee).toBeTruthy();
@@ -103,7 +127,7 @@ export const crudTests = (driver: DbDriver, dropTable: (table: Table<any>) => Pr
       const testEmployee1: Omit<Employee, keyof Record> = { name: 'Veronica', department: 'Cake Factory' };
       const testEmployee2: Omit<Employee, keyof Record> = { name: 'Brent', department: 'Cake Factory' };
       const testEmployee3: Omit<Employee, keyof Record> = { name: 'Sean', department: 'Pug Playhouse' };
-      const emplyeeTable: Table<Employee> = new EmployeeTable();
+      const emplyeeTable: Table<Employee> = new EmployeeTestTable();
       const fetchedEmployee1 = await db.insert(emplyeeTable, testEmployee1);
       const fetchedEmployee2 = await db.insert(emplyeeTable, testEmployee2);
       const fetchedEmployee3 = await db.insert(emplyeeTable, testEmployee3);
@@ -123,7 +147,7 @@ export const crudTests = (driver: DbDriver, dropTable: (table: Table<any>) => Pr
       const testEmployee1: Omit<Employee, keyof Record> = { name: 'Veronica', department: 'Cake Factory' };
       const testEmployee2: Omit<Employee, keyof Record> = { name: 'Brent', department: 'Cake Factory' };
       const testEmployee3: Omit<Employee, keyof Record> = { name: 'Sean', department: 'Pug Playhouse' };
-      const emplyeeTable: Table<Employee> = new EmployeeTable();
+      const emplyeeTable: Table<Employee> = new EmployeeTestTable();
       const fetchedEmployee1 = await db.insert(emplyeeTable, testEmployee1);
       const fetchedEmployee2 = await db.insert(emplyeeTable, testEmployee2);
       const fetchedEmployee3 = await db.insert(emplyeeTable, testEmployee3);
@@ -144,7 +168,7 @@ export const crudTests = (driver: DbDriver, dropTable: (table: Table<any>) => Pr
         jobTitle: null,
         isRemote: false,
       };
-      const emplyeeTable: Table<Employee> = new EmployeeTable();
+      const emplyeeTable: Table<Employee> = new EmployeeTestTable();
       const insertedEmployee = await db.insert(emplyeeTable, testEmployee);
       const fetchedEmployee = await db.get(emplyeeTable, { id: insertedEmployee.id });
 
@@ -160,7 +184,7 @@ export const crudTests = (driver: DbDriver, dropTable: (table: Table<any>) => Pr
         jobTitle: 'Cowboy',
         isRemote: false,
       };
-      const emplyeeTable: Table<Employee> = new EmployeeTable();
+      const emplyeeTable: Table<Employee> = new EmployeeTestTable();
       const insertedEmployee = await db.insert(emplyeeTable, testEmployee);
       const fetchedEmployee = await db.get(emplyeeTable, { id: insertedEmployee.id });
       expect(fetchedEmployee).toBeTruthy();
@@ -176,7 +200,7 @@ export const crudTests = (driver: DbDriver, dropTable: (table: Table<any>) => Pr
         jobTitle: null,
         isRemote: false,
       };
-      const emplyeeTable: Table<Employee> = new EmployeeTable();
+      const emplyeeTable: Table<Employee> = new EmployeeTestTable();
       const insertedEmployee = await db.insert(emplyeeTable, testEmployee);
 
       const qb = new QueryBuilder<Employee>(emplyeeTable.name)
@@ -194,7 +218,7 @@ export const crudTests = (driver: DbDriver, dropTable: (table: Table<any>) => Pr
       const testEmployee1: Omit<Employee, keyof Record> = { name: 'Veronica', jobTitle: 'Engineer' };
       const testEmployee2: Omit<Employee, keyof Record> = { name: 'Zenyatta', jobTitle: null };
       const testEmployee3: Omit<Employee, keyof Record> = { name: 'Cassidy', jobTitle: 'Cowboy' };
-      const emplyeeTable: Table<Employee> = new EmployeeTable();
+      const emplyeeTable: Table<Employee> = new EmployeeTestTable();
       const insertedEmployee1 = await db.insert(emplyeeTable, testEmployee1);
       const insertedEmployee2 = await db.insert(emplyeeTable, testEmployee2);
       const insertedEmployee3 = await db.insert(emplyeeTable, testEmployee3);
@@ -241,7 +265,7 @@ export const crudTests = (driver: DbDriver, dropTable: (table: Table<any>) => Pr
         jobTitle: 'Cowboy',
         startDate: new Date('2016-05-24T00:00:00Z'),
       };
-      const employeeTable: Table<Employee> = new EmployeeTable();
+      const employeeTable: Table<Employee> = new EmployeeTestTable();
 
       const insertedEmployee1 = await db.insert(employeeTable, testEmployee1);
       const insertedEmployee2 = await db.insert(employeeTable, testEmployee2);
@@ -279,7 +303,7 @@ export const crudTests = (driver: DbDriver, dropTable: (table: Table<any>) => Pr
         name: 'Cassidy',
         jobTitle: 'Cowboy',
       };
-      const emplyeeTable: Table<Employee> = new EmployeeTable();
+      const emplyeeTable: Table<Employee> = new EmployeeTestTable();
 
       const insertedEmployee1 = await db.insert(emplyeeTable, testEmployee1);
       const insertedEmployee2 = await db.insert(emplyeeTable, testEmployee2);
@@ -308,7 +332,7 @@ export const crudTests = (driver: DbDriver, dropTable: (table: Table<any>) => Pr
     test('CRUD operations with undefined values', async () => {
       const testEmployee1: Omit<Employee, keyof Record> = { name: 'Veronica', jobTitle: 'Software Engineer' };
       const testEmployee2: Omit<Employee, keyof Record> = { name: 'Brent', jobTitle: undefined };
-      const emplyeeTable: Table<Employee> = new EmployeeTable();
+      const emplyeeTable: Table<Employee> = new EmployeeTestTable();
 
       // Insert operation with undefined values
       await expect(db.insert(emplyeeTable, testEmployee2)).rejects.toThrow();
@@ -338,5 +362,127 @@ export const crudTests = (driver: DbDriver, dropTable: (table: Table<any>) => Pr
       });
       await db.delete(emplyeeTable, deleteValidQuery);
     });
+
+    test('Insert with reserved words', async () => {
+      const testRecord: Omit<ReservedWordTest, keyof Record> = { name: 'Test Name', order: '1', select: 'Option 1' };
+      const table: Table<ReservedWordTest> = new ReservedWordTestTable();
+      const insertedRecord = await db.insert(table, testRecord);
+      const fetchedRecord = await db.get(table, { id: insertedRecord.id });
+      expect(fetchedRecord).toBeTruthy();
+      await db.delete(table, { id: fetchedRecord.id });
+    });
+
+    test('Update with reserved words', async () => {
+      const testRecord: Omit<ReservedWordTest, keyof Record> = { name: 'Test Name', order: '1', select: 'Option 1' };
+      const table: Table<ReservedWordTest> = new ReservedWordTestTable();
+      const insertedRecord = await db.insert(table, testRecord);
+      const updateCount = await db.update(
+        table,
+        {
+          name: 'Updated Name',
+          order: '2',
+          join: 'Join Option',
+        },
+        { id: insertedRecord.id }
+      );
+      expect(updateCount).toBe(1);
+      const fetchedRecord = await db.get(table, { id: insertedRecord.id });
+      expect(fetchedRecord.name).toBe('Updated Name');
+      expect(fetchedRecord.order).toBe('2');
+      expect(fetchedRecord.join).toBe('Join Option');
+      await db.delete(table, { id: fetchedRecord.id });
+    });
+
+    test('Delete with reserved words', async () => {
+      const testRecord: Omit<ReservedWordTest, keyof Record> = { name: 'Test Name', order: '1', select: 'Option 1' };
+      const table: Table<ReservedWordTest> = new ReservedWordTestTable();
+      const insertedRecord = await db.insert(table, testRecord);
+      let fetchedRecord = await db.get(table, { id: insertedRecord.id });
+      expect(fetchedRecord).toBeTruthy();
+      const deleteCount = await db.delete(table, { id: fetchedRecord.id });
+      expect(deleteCount).toBe(1);
+      fetchedRecord = await db.get(table, { id: insertedRecord.id });
+      expect(fetchedRecord).toBeFalsy();
+    });
+
+    test('Query with reserved words', async () => {
+      const testRecord1: Omit<ReservedWordTest, keyof Record> = { name: 'Test Name 1', order: '1', select: 'Option 1' };
+      const testRecord2: Omit<ReservedWordTest, keyof Record> = { name: 'Test Name 2', order: '1', select: 'Option 1' };
+      const testRecord3: Omit<ReservedWordTest, keyof Record> = { name: 'Test Name 3', order: '2', select: 'Option 2' };
+      const table: Table<ReservedWordTest> = new ReservedWordTestTable();
+      const insertedRecord1 = await db.insert(table, testRecord1);
+      const insertedRecord2 = await db.insert(table, testRecord2);
+      const insertedRecord3 = await db.insert(table, testRecord3);
+      const fetchedRecords = await db.query(table, { order: '1', select: 'Option 1' });
+      expect(fetchedRecords.length).toBe(2);
+      expect(fetchedRecords[0].name).toBe('Test Name 1');
+      expect(fetchedRecords[1].name).toBe('Test Name 2');
+      const qb = new QueryBuilder<ReservedWordTest>(table.name).condition({
+        field: 'id',
+        operator: 'IN',
+        value: [insertedRecord1.id, insertedRecord2.id, insertedRecord3.id],
+      });
+      await db.delete(table, qb);
+    });
+
+    test('Query with sort and reserved words', async () => {
+      const testRecord1: Omit<ReservedWordTest, keyof Record> = { name: 'Test Name 1', order: '1', select: 'Option 1' };
+      const testRecord2: Omit<ReservedWordTest, keyof Record> = { name: 'Test Name 2', order: '2', select: 'Option 2' };
+      const testRecord3: Omit<ReservedWordTest, keyof Record> = { name: 'Test Name 3', order: '3', select: 'Option 3' };
+      const table: Table<ReservedWordTest> = new ReservedWordTestTable();
+
+      const insertedRecord1 = await db.insert(table, testRecord1);
+      const insertedRecord2 = await db.insert(table, testRecord2);
+      const insertedRecord3 = await db.insert(table, testRecord3);
+
+      const sortQuery = new QueryBuilder<ReservedWordTest>(table.name).sort([
+        { field: 'order', byValues: ['1', '2', '3'] },
+      ]);
+      const sortResults = await db.query(table, sortQuery);
+
+      // Assertions
+      expect(sortResults.length).toBe(3);
+      expect(sortResults[0].order).toBe('1');
+      expect(sortResults[1].order).toBe('2');
+      expect(sortResults[2].order).toBe('3');
+
+      // Clean up
+      const qb = new QueryBuilder<ReservedWordTest>(table.name).condition({
+        field: 'id',
+        operator: 'IN',
+        value: [insertedRecord1.id, insertedRecord2.id, insertedRecord3.id],
+      });
+      await db.delete(table, qb);
+    });
+
+    test('Query with reserved words and subquery', async () => {
+      const testRecord1: Omit<ReservedWordTest, keyof Record> = { name: 'Test Name 1', order: '1', select: 'Option 1' };
+      const testRecord2: Omit<ReservedWordTest, keyof Record> = { name: 'Test Name 2', order: '2', select: 'Option 2' };
+      const table: Table<ReservedWordTest> = new ReservedWordTestTable();
+
+      const insertedRecord1 = await db.insert(table, testRecord1);
+      const insertedRecord2 = await db.insert(table, testRecord2);
+
+      const subQb = new QueryBuilder<ReservedWordTest>(table.name).select({ fields: ['id'] }).condition({
+        field: 'select',
+        operator: '=',
+        value: 'Option 1',
+      });
+
+      const qb = new QueryBuilder<ReservedWordTest>(table.name).condition({
+        field: 'id',
+        operator: 'IN',
+        value: subQb,
+      });
+
+      // Execute the query
+      const results = await db.query(table, qb);
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe('Test Name 1');
+
+      // Clean up
+      await db.delete(table, { id: insertedRecord1.id });
+      await db.delete(table, { id: insertedRecord2.id });
+    }, 10000);
   };
 };

--- a/packages/db/test/TableManagerTests.ts
+++ b/packages/db/test/TableManagerTests.ts
@@ -20,7 +20,7 @@ interface User extends Record {
   active: boolean;
 }
 
-class UserTable extends Table<User> {
+class UserTestTable extends Table<User> {
   name = 'db_test_user';
   columns = withRecordColumns<User>({
     name: new StringColumn('name'),
@@ -87,7 +87,7 @@ export const tableManagerTests = (
 
     afterEach(async () => {
       await dropTable(new ColumnTypesTable());
-      await dropTable(new UserTable());
+      await dropTable(new UserTestTable());
     });
 
     afterAll(async () => {
@@ -97,7 +97,7 @@ export const tableManagerTests = (
     });
 
     test('create primary key', async () => {
-      const userTable = new UserTable();
+      const userTable = new UserTestTable();
       await tableManager.loadTable(userTable);
       expect(await tableManager.tableExists(userTable)).toBeTruthy();
       const primaryKey = await tableManager.schemaMetadata.getPrimaryKey(userTable);
@@ -106,7 +106,7 @@ export const tableManagerTests = (
     });
 
     test('create columns', async () => {
-      const userTable = new UserTable();
+      const userTable = new UserTestTable();
       await tableManager.loadTable(userTable);
       expect(await tableManager.tableExists(userTable)).toBeTruthy();
       expect(await tableManager.schemaMetadata.columnExists(userTable.columns.name.name, userTable)).toBeTruthy();
@@ -115,7 +115,7 @@ export const tableManagerTests = (
     });
 
     test('add column via alter', async () => {
-      const userTable = new UserTable();
+      const userTable = new UserTestTable();
       const dataColumn = new ObjectColumn('data');
       await tableManager.loadTable(userTable);
       expect(await tableManager.tableExists(userTable)).toBeTruthy();
@@ -133,7 +133,7 @@ export const tableManagerTests = (
     });
 
     test('columns created with correct types', async () => {
-      const userTable = new UserTable();
+      const userTable = new UserTestTable();
       const columnTypesTable = new ColumnTypesTable();
       await tableManager.loadTable(userTable);
       await tableManager.loadTable(columnTypesTable);
@@ -178,7 +178,7 @@ export const tableManagerTests = (
     });
 
     test('columns created with correct options', async () => {
-      const userTable = new UserTable();
+      const userTable = new UserTestTable();
       const columnTypesTable = new ColumnTypesTable();
       await tableManager.loadTable(userTable);
       await tableManager.loadTable(columnTypesTable);
@@ -203,7 +203,7 @@ export const tableManagerTests = (
         return;
       }
 
-      const userTable = new UserTable();
+      const userTable = new UserTestTable();
       await tableManager.loadTable(userTable);
       expect(await tableManager.tableExists(userTable)).toBeTruthy();
       expect(await tableManager.schemaMetadata.columnExists(userTable.columns.name.name, userTable)).toBeTruthy();
@@ -219,7 +219,7 @@ export const tableManagerTests = (
         return;
       }
 
-      const userTable = new UserTable();
+      const userTable = new UserTestTable();
       const columnTypesTable = new ColumnTypesTable();
       await tableManager.loadTable(userTable);
       await tableManager.loadTable(columnTypesTable);
@@ -287,7 +287,7 @@ export const tableManagerTests = (
     });
 
     test('alter unique constraint', async () => {
-      const userTable = new UserTable();
+      const userTable = new UserTestTable();
       const columnTypesTable = new ColumnTypesTable();
       await tableManager.loadTable(userTable);
       columnTypesTable.columns.text.options = { defaultValue: async () => 'asdf' };
@@ -409,7 +409,7 @@ export const tableManagerTests = (
         return;
       }
 
-      const userTable = new UserTable();
+      const userTable = new UserTestTable();
       const columnTypesTable = new ColumnTypesTable();
       await tableManager.loadTable(userTable);
       columnTypesTable.columns.text.options = { defaultValue: async () => 'asdf' };
@@ -528,7 +528,7 @@ export const tableManagerTests = (
     });
 
     test('create index', async () => {
-      const userTable = new UserTable();
+      const userTable = new UserTestTable();
       await tableManager.loadTable(userTable);
       expect(await tableManager.tableExists(userTable)).toBeTruthy();
       const indexes = await tableManager.schemaMetadata.getIndexes(userTable);
@@ -537,7 +537,7 @@ export const tableManagerTests = (
     });
 
     test('alter index', async () => {
-      const userTable = new UserTable();
+      const userTable = new UserTestTable();
       await tableManager.loadTable(userTable);
       expect(await tableManager.tableExists(userTable)).toBeTruthy();
       let indexes = await tableManager.schemaMetadata.getIndexes(userTable);

--- a/packages/query/test/Aggregates.test.ts
+++ b/packages/query/test/Aggregates.test.ts
@@ -16,16 +16,16 @@ describe('QueryBuilder - Aggregate Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT COUNT(id) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT COUNT(`id`) FROM `test`.`Employee`;');
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toBe('SELECT COUNT(id) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT COUNT(`id`) FROM `test`.`Employee`;');
     expect(result.params).toEqual([]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toBe('SELECT COUNT(id) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT COUNT(`id`) FROM `test`.`Employee`;');
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});
   });
@@ -35,16 +35,16 @@ describe('QueryBuilder - Aggregate Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT COUNT(*) as count FROM test.Employee;');
+    expect(result.sql).toBe('SELECT COUNT(*) as count FROM `test`.`Employee`;');
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toBe('SELECT COUNT(*) as count FROM test.Employee;');
+    expect(result.sql).toBe('SELECT COUNT(*) as count FROM `test`.`Employee`;');
     expect(result.params).toEqual([]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toBe('SELECT COUNT(*) as count FROM test.Employee;');
+    expect(result.sql).toBe('SELECT COUNT(*) as count FROM `test`.`Employee`;');
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});
   });
@@ -53,14 +53,14 @@ describe('QueryBuilder - Aggregate Support', () => {
     const qb = new QueryBuilder<Employee>(tableName).aggregate({ function: 'SUM', field: 'salary' });
 
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT SUM(salary) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT SUM(`salary`) FROM `test`.`Employee`;');
 
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toBe('SELECT SUM(salary) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT SUM(`salary`) FROM `test`.`Employee`;');
     expect(result.params).toEqual([]);
 
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toBe('SELECT SUM(salary) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT SUM(`salary`) FROM `test`.`Employee`;');
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});
   });
@@ -69,14 +69,14 @@ describe('QueryBuilder - Aggregate Support', () => {
     const qb = new QueryBuilder<Employee>(tableName).aggregate({ function: 'AVG', field: 'age' });
 
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT AVG(age) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT AVG(`age`) FROM `test`.`Employee`;');
 
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toBe('SELECT AVG(age) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT AVG(`age`) FROM `test`.`Employee`;');
     expect(result.params).toEqual([]);
 
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toBe('SELECT AVG(age) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT AVG(`age`) FROM `test`.`Employee`;');
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});
   });
@@ -85,14 +85,14 @@ describe('QueryBuilder - Aggregate Support', () => {
     const qb = new QueryBuilder<Employee>(tableName).aggregate({ function: 'MIN', field: 'age' });
 
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT MIN(age) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT MIN(`age`) FROM `test`.`Employee`;');
 
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toBe('SELECT MIN(age) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT MIN(`age`) FROM `test`.`Employee`;');
     expect(result.params).toEqual([]);
 
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toBe('SELECT MIN(age) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT MIN(`age`) FROM `test`.`Employee`;');
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});
   });
@@ -102,16 +102,16 @@ describe('QueryBuilder - Aggregate Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT MAX(age) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT MAX(`age`) FROM `test`.`Employee`;');
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toBe('SELECT MAX(age) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT MAX(`age`) FROM `test`.`Employee`;');
     expect(result.params).toEqual([]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toBe('SELECT MAX(age) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT MAX(`age`) FROM `test`.`Employee`;');
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});
   });
@@ -123,16 +123,16 @@ describe('QueryBuilder - Aggregate Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT COUNT(id), AVG(age) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT COUNT(`id`), AVG(`age`) FROM `test`.`Employee`;');
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toBe('SELECT COUNT(id), AVG(age) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT COUNT(`id`), AVG(`age`) FROM `test`.`Employee`;');
     expect(result.params).toEqual([]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toBe('SELECT COUNT(id), AVG(age) FROM test.Employee;');
+    expect(result.sql).toBe('SELECT COUNT(`id`), AVG(`age`) FROM `test`.`Employee`;');
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});
   });
@@ -144,16 +144,16 @@ describe('QueryBuilder - Aggregate Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT AVG(salary) FROM test.Employee WHERE age > 30;');
+    expect(result.sql).toBe('SELECT AVG(`salary`) FROM `test`.`Employee` WHERE `age` > 30;');
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toContain('SELECT AVG(salary) FROM test.Employee WHERE age > ?;');
+    expect(result.sql).toContain('SELECT AVG(`salary`) FROM `test`.`Employee` WHERE `age` > ?;');
     expect(result.params).toEqual([30]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('SELECT AVG(salary) FROM test.Employee WHERE age > @param0;');
+    expect(result.sql).toContain('SELECT AVG(`salary`) FROM `test`.`Employee` WHERE `age` > @param0;');
     expect(result.namedParams?.params).toEqual({ param0: 30 });
     expect(result.namedParams?.types).toEqual({ param0: 'number' });
   });
@@ -163,16 +163,16 @@ describe('QueryBuilder - Aggregate Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT SUM(salary) FROM test.Employee GROUP BY age;');
+    expect(result.sql).toBe('SELECT SUM(`salary`) FROM `test`.`Employee` GROUP BY `age`;');
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toBe('SELECT SUM(salary) FROM test.Employee GROUP BY age;');
+    expect(result.sql).toBe('SELECT SUM(`salary`) FROM `test`.`Employee` GROUP BY `age`;');
     expect(result.params).toEqual([]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toBe('SELECT SUM(salary) FROM test.Employee GROUP BY age;');
+    expect(result.sql).toBe('SELECT SUM(`salary`) FROM `test`.`Employee` GROUP BY `age`;');
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});
   });

--- a/packages/query/test/ConditionalOperators.test.ts
+++ b/packages/query/test/ConditionalOperators.test.ts
@@ -16,16 +16,16 @@ describe('QueryBuilder - Conditional Operator Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT * FROM test.Employee WHERE id = 1;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` WHERE `id` = 1;');
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE id = ?');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `id` = ?');
     expect(result.params).toEqual([1]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE id = @param0');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `id` = @param0');
     expect(result.namedParams?.params).toEqual({ param0: 1 });
     expect(result.namedParams?.types).toEqual({ param0: 'number' });
 
@@ -39,7 +39,7 @@ describe('QueryBuilder - Conditional Operator Support', () => {
     // Operator '=' with null is properly converted to IS NULL
     const qbNull = new QueryBuilder<Employee>(tableName).condition({ field: 'id', operator: '=', value: null });
     result = qbNull.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE id IS NULL');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `id` IS NULL');
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});
   });
@@ -55,16 +55,16 @@ describe('QueryBuilder - Conditional Operator Support', () => {
 
       // Standard SQL output
       let result = qb.toSql({ dbName });
-      expect(result.sql).toBe(`SELECT * FROM test.Employee WHERE name ${operator} '${value}';`);
+      expect(result.sql).toBe(`SELECT * FROM \`test\`.\`Employee\` WHERE \`name\` ${operator} '${value}';`);
 
       // SQL output with positional parameters
       result = qb.toSql({ dbName, useParams: true });
-      expect(result.sql).toContain(`SELECT * FROM test.Employee WHERE name ${operator} ?`);
+      expect(result.sql).toContain(`SELECT * FROM \`test\`.\`Employee\` WHERE \`name\` ${operator} ?`);
       expect(result.params).toEqual([value]);
 
       // SQL output with named parameters and types
       result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-      expect(result.sql).toContain(`SELECT * FROM test.Employee WHERE name ${operator} @param0`);
+      expect(result.sql).toContain(`SELECT * FROM \`test\`.\`Employee\` WHERE \`name\` ${operator} @param0`);
       expect(result.namedParams?.params).toEqual({ param0: value });
       expect(result.namedParams?.types).toEqual({ param0: 'string' });
     });
@@ -85,16 +85,16 @@ describe('QueryBuilder - Conditional Operator Support', () => {
 
       // Standard SQL output
       let result = qb.toSql({ dbName });
-      expect(result.sql).toBe(`SELECT * FROM test.Employee WHERE age ${operator} ${value};`);
+      expect(result.sql).toBe(`SELECT * FROM \`test\`.\`Employee\` WHERE \`age\` ${operator} ${value};`);
 
       // SQL output with positional parameters
       result = qb.toSql({ dbName, useParams: true });
-      expect(result.sql).toContain(`SELECT * FROM test.Employee WHERE age ${operator} ?`);
+      expect(result.sql).toContain(`SELECT * FROM \`test\`.\`Employee\` WHERE \`age\` ${operator} ?`);
       expect(result.params).toEqual([value]);
 
       // SQL output with named parameters and types
       result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-      expect(result.sql).toContain(`SELECT * FROM test.Employee WHERE age ${operator} @param0`);
+      expect(result.sql).toContain(`SELECT * FROM \`test\`.\`Employee\` WHERE \`age\` ${operator} @param0`);
       expect(result.namedParams?.params).toEqual({ param0: value });
       expect(result.namedParams?.types).toEqual({ param0: 'number' });
     });
@@ -105,16 +105,16 @@ describe('QueryBuilder - Conditional Operator Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe("SELECT * FROM test.Employee WHERE country NOT 'Canada';");
+    expect(result.sql).toBe("SELECT * FROM `test`.`Employee` WHERE `country` NOT 'Canada';");
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE country NOT ?');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `country` NOT ?');
     expect(result.params).toEqual(['Canada']);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE country NOT @param0');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `country` NOT @param0');
     expect(result.namedParams?.params).toEqual({ param0: 'Canada' });
     expect(result.namedParams?.types).toEqual({ param0: 'string' });
 
@@ -127,17 +127,19 @@ describe('QueryBuilder - Conditional Operator Support', () => {
 
     // Standard SQL output with NOT and OR conditions
     result = qbOr.toSql({ dbName });
-    expect(result.sql).toBe("SELECT * FROM test.Employee WHERE country NOT 'Canada' AND (age = 25 OR age = 30);");
+    expect(result.sql).toBe(
+      "SELECT * FROM `test`.`Employee` WHERE `country` NOT 'Canada' AND (`age` = 25 OR `age` = 30);"
+    );
 
     // SQL output with positional parameters with NOT and OR conditions
     result = qbOr.toSql({ dbName, useParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE country NOT ? AND (age = ? OR age = ?)');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `country` NOT ? AND (`age` = ? OR `age` = ?)');
     expect(result.params).toEqual(['Canada', 25, 30]);
 
     // SQL output with named parameters and types with NOT and OR conditions
     result = qbOr.toSql({ dbName, useParams: true, useNamedParams: true });
     expect(result.sql).toContain(
-      'SELECT * FROM test.Employee WHERE country NOT @param0 AND (age = @param1 OR age = @param2)'
+      'SELECT * FROM `test`.`Employee` WHERE `country` NOT @param0 AND (`age` = @param1 OR `age` = @param2)'
     );
     expect(result.namedParams?.params).toEqual({ param0: 'Canada', param1: 25, param2: 30 });
     expect(result.namedParams?.types).toEqual({ param0: 'string', param1: 'number', param2: 'number' });
@@ -155,16 +157,16 @@ describe('QueryBuilder - Conditional Operator Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT * FROM test.Employee WHERE id IN (1, 2, 3);');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` WHERE `id` IN (1, 2, 3);');
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE id IN (?, ?, ?)');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `id` IN (?, ?, ?)');
     expect(result.params).toEqual([1, 2, 3]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE id IN UNNEST(@param0)');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `id` IN UNNEST(@param0)');
     expect(result.namedParams?.params).toEqual({ param0: [1, 2, 3] });
     expect(result.namedParams?.types).toEqual({ param0: { type: 'array', child: { type: 'number' } } });
   });
@@ -174,16 +176,16 @@ describe('QueryBuilder - Conditional Operator Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe("SELECT * FROM test.Employee WHERE name LIKE '%John%';");
+    expect(result.sql).toBe("SELECT * FROM `test`.`Employee` WHERE `name` LIKE '%John%';");
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE name LIKE ?');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `name` LIKE ?');
     expect(result.params).toEqual(['%John%']);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE name LIKE @param0');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `name` LIKE @param0');
     expect(result.namedParams?.params).toEqual({ param0: '%John%' });
     expect(result.namedParams?.types).toEqual({ param0: 'string' });
 
@@ -204,16 +206,16 @@ describe('QueryBuilder - Conditional Operator Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe("SELECT * FROM test.Employee WHERE name NOT LIKE '%John%';");
+    expect(result.sql).toBe("SELECT * FROM `test`.`Employee` WHERE `name` NOT LIKE '%John%';");
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE name NOT LIKE ?');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `name` NOT LIKE ?');
     expect(result.params).toEqual(['%John%']);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE name NOT LIKE @param0');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `name` NOT LIKE @param0');
     expect(result.namedParams?.params).toEqual({ param0: '%John%' });
     expect(result.namedParams?.types).toEqual({ param0: 'string' });
 
@@ -230,16 +232,16 @@ describe('QueryBuilder - Conditional Operator Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT * FROM test.Employee WHERE age BETWEEN 18 AND 30;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` WHERE `age` BETWEEN 18 AND 30;');
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE age BETWEEN ? AND ?');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `age` BETWEEN ? AND ?');
     expect(result.params).toEqual([18, 30]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE age BETWEEN @param0 AND @param1');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `age` BETWEEN @param0 AND @param1');
     expect(result.namedParams?.params).toEqual({ param0: 18, param1: 30 });
     expect(result.namedParams?.types).toEqual({ param0: 'number', param1: 'number' });
 
@@ -256,16 +258,16 @@ describe('QueryBuilder - Conditional Operator Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT * FROM test.Employee WHERE country IS NULL;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` WHERE `country` IS NULL;');
 
     // SQL output with positional parameters (This should remain the same as IS NULL doesn't use parameters)
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toBe('SELECT * FROM test.Employee WHERE country IS NULL;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` WHERE `country` IS NULL;');
     expect(result.params).toEqual([]);
 
     // SQL output with named parameters and types (Named params don't apply to IS NULL, but included for consistency)
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toBe('SELECT * FROM test.Employee WHERE country IS NULL;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` WHERE `country` IS NULL;');
     // No namedParams should be added for IS NULL
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});
@@ -276,16 +278,16 @@ describe('QueryBuilder - Conditional Operator Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT * FROM test.Employee WHERE country IS NOT NULL;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` WHERE `country` IS NOT NULL;');
 
     // SQL output with positional parameters (This should remain the same as IS NOT NULL doesn't use parameters)
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toBe('SELECT * FROM test.Employee WHERE country IS NOT NULL;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` WHERE `country` IS NOT NULL;');
     expect(result.params).toEqual([]);
 
     // SQL output with named parameters and types (Named params don't apply to IS NOT NULL, but included for consistency)
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toBe('SELECT * FROM test.Employee WHERE country IS NOT NULL;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` WHERE `country` IS NOT NULL;');
     // No namedParams should be added for IS NOT NULL
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});
@@ -296,16 +298,16 @@ describe('QueryBuilder - Conditional Operator Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT * FROM test.Employee WHERE 1=0;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` WHERE 1=0;');
 
     // SQL output with positional parameters (This should remain the same as IS NOT NULL doesn't use parameters)
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toBe('SELECT * FROM test.Employee WHERE 1=0;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` WHERE 1=0;');
     expect(result.params).toEqual([]);
 
     // SQL output with named parameters and types (Named params don't apply to IS NOT NULL, but included for consistency)
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toBe('SELECT * FROM test.Employee WHERE 1=0;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` WHERE 1=0;');
     // No namedParams should be added for IS NOT NULL
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});
@@ -316,16 +318,16 @@ describe('QueryBuilder - Conditional Operator Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT * FROM test.Employee WHERE 1=0;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` WHERE 1=0;');
 
     // SQL output with positional parameters (This should remain the same as IS NOT NULL doesn't use parameters)
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toBe('SELECT * FROM test.Employee WHERE 1=0;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` WHERE 1=0;');
     expect(result.params).toEqual([]);
 
     // SQL output with named parameters and types (Named params don't apply to IS NOT NULL, but included for consistency)
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toBe('SELECT * FROM test.Employee WHERE 1=0;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` WHERE 1=0;');
     // No namedParams should be added for IS NOT NULL
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});

--- a/packages/query/test/Grouping.test.ts
+++ b/packages/query/test/Grouping.test.ts
@@ -18,16 +18,16 @@ describe('QueryBuilder - GROUP BY Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT * FROM test.Employee GROUP BY department;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` GROUP BY `department`;');
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toBe('SELECT * FROM test.Employee GROUP BY department;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` GROUP BY `department`;');
     expect(result.params).toEqual([]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toBe('SELECT * FROM test.Employee GROUP BY department;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` GROUP BY `department`;');
     // GroupBy doesn't use params, so these should be empty
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});
@@ -40,16 +40,16 @@ describe('QueryBuilder - GROUP BY Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT * FROM test.Employee WHERE age > 30 GROUP BY department;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` WHERE `age` > 30 GROUP BY `department`;');
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE age > ? GROUP BY department;');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `age` > ? GROUP BY `department`;');
     expect(result.params).toEqual([30]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE age > @param0 GROUP BY department;');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `age` > @param0 GROUP BY `department`;');
     expect(result.namedParams?.params).toEqual({ param0: 30 });
     expect(result.namedParams?.types).toEqual({ param0: 'number' });
   });
@@ -61,16 +61,16 @@ describe('QueryBuilder - GROUP BY Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT AVG(salary) FROM test.Employee GROUP BY department;');
+    expect(result.sql).toBe('SELECT AVG(`salary`) FROM `test`.`Employee` GROUP BY `department`;');
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toBe('SELECT AVG(salary) FROM test.Employee GROUP BY department;');
+    expect(result.sql).toBe('SELECT AVG(`salary`) FROM `test`.`Employee` GROUP BY `department`;');
     expect(result.params).toEqual([]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toBe('SELECT AVG(salary) FROM test.Employee GROUP BY department;');
+    expect(result.sql).toBe('SELECT AVG(`salary`) FROM `test`.`Employee` GROUP BY `department`;');
     // Aggregate functions and GroupBy don't use params, so these should be empty
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});
@@ -81,16 +81,16 @@ describe('QueryBuilder - GROUP BY Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT * FROM test.Employee GROUP BY department, age;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` GROUP BY `department`, `age`;');
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toBe('SELECT * FROM test.Employee GROUP BY department, age;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` GROUP BY `department`, `age`;');
     expect(result.params).toEqual([]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toBe('SELECT * FROM test.Employee GROUP BY department, age;');
+    expect(result.sql).toBe('SELECT * FROM `test`.`Employee` GROUP BY `department`, `age`;');
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});
   });
@@ -103,16 +103,16 @@ describe('QueryBuilder - GROUP BY Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT MAX(salary), MIN(age) FROM test.Employee GROUP BY department;');
+    expect(result.sql).toBe('SELECT MAX(`salary`), MIN(`age`) FROM `test`.`Employee` GROUP BY `department`;');
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toBe('SELECT MAX(salary), MIN(age) FROM test.Employee GROUP BY department;');
+    expect(result.sql).toBe('SELECT MAX(`salary`), MIN(`age`) FROM `test`.`Employee` GROUP BY `department`;');
     expect(result.params).toEqual([]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toBe('SELECT MAX(salary), MIN(age) FROM test.Employee GROUP BY department;');
+    expect(result.sql).toBe('SELECT MAX(`salary`), MIN(`age`) FROM `test`.`Employee` GROUP BY `department`;');
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});
   });
@@ -125,16 +125,20 @@ describe('QueryBuilder - GROUP BY Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe("SELECT COUNT(id) FROM test.Employee WHERE department = 'Engineering' GROUP BY age;");
+    expect(result.sql).toBe(
+      "SELECT COUNT(`id`) FROM `test`.`Employee` WHERE `department` = 'Engineering' GROUP BY `age`;"
+    );
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toContain('SELECT COUNT(id) FROM test.Employee WHERE department = ? GROUP BY age;');
+    expect(result.sql).toContain('SELECT COUNT(`id`) FROM `test`.`Employee` WHERE `department` = ? GROUP BY `age`;');
     expect(result.params).toEqual(['Engineering']);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('SELECT COUNT(id) FROM test.Employee WHERE department = @param0 GROUP BY age;');
+    expect(result.sql).toContain(
+      'SELECT COUNT(`id`) FROM `test`.`Employee` WHERE `department` = @param0 GROUP BY `age`;'
+    );
     expect(result.namedParams?.params).toEqual({ param0: 'Engineering' });
     expect(result.namedParams?.types).toEqual({ param0: 'string' });
   });
@@ -146,16 +150,16 @@ describe('QueryBuilder - GROUP BY Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe('SELECT AVG(salary) FROM test.Employee GROUP BY department, age;');
+    expect(result.sql).toBe('SELECT AVG(`salary`) FROM `test`.`Employee` GROUP BY `department`, `age`;');
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toBe('SELECT AVG(salary) FROM test.Employee GROUP BY department, age;');
+    expect(result.sql).toBe('SELECT AVG(`salary`) FROM `test`.`Employee` GROUP BY `department`, `age`;');
     expect(result.params).toEqual([]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toBe('SELECT AVG(salary) FROM test.Employee GROUP BY department, age;');
+    expect(result.sql).toBe('SELECT AVG(`salary`) FROM `test`.`Employee` GROUP BY `department`, `age`;');
     expect(result.namedParams?.params).toEqual({});
     expect(result.namedParams?.types).toEqual({});
   });
@@ -172,20 +176,20 @@ describe('QueryBuilder - GROUP BY Support', () => {
     // Standard SQL output
     let result = qb.toSql({ dbName });
     expect(result.sql).toBe(
-      'SELECT SUM(salary) FROM test.Employee WHERE (age > 30 AND yearsOfService < 10) GROUP BY department;'
+      'SELECT SUM(`salary`) FROM `test`.`Employee` WHERE (`age` > 30 AND `yearsOfService` < 10) GROUP BY `department`;'
     );
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
     expect(result.sql).toContain(
-      'SELECT SUM(salary) FROM test.Employee WHERE (age > ? AND yearsOfService < ?) GROUP BY department;'
+      'SELECT SUM(`salary`) FROM `test`.`Employee` WHERE (`age` > ? AND `yearsOfService` < ?) GROUP BY `department`;'
     );
     expect(result.params).toEqual([30, 10]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
     expect(result.sql).toContain(
-      'SELECT SUM(salary) FROM test.Employee WHERE (age > @param0 AND yearsOfService < @param1) GROUP BY department;'
+      'SELECT SUM(`salary`) FROM `test`.`Employee` WHERE (`age` > @param0 AND `yearsOfService` < @param1) GROUP BY `department`;'
     );
     expect(result.namedParams?.params).toEqual({ param0: 30, param1: 10 });
     expect(result.namedParams?.types).toEqual({ param0: 'number', param1: 'number' });
@@ -205,20 +209,20 @@ describe('QueryBuilder - GROUP BY Support', () => {
     // Standard SQL output
     let result = qb.toSql({ dbName });
     expect(result.sql).toBe(
-      "SELECT COUNT(id), AVG(salary) FROM test.Employee WHERE department = 'Engineering' AND (age > 50 OR yearsOfService >= 20) GROUP BY department, age;"
+      "SELECT COUNT(`id`), AVG(`salary`) FROM `test`.`Employee` WHERE `department` = 'Engineering' AND (`age` > 50 OR `yearsOfService` >= 20) GROUP BY `department`, `age`;"
     );
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
     expect(result.sql).toContain(
-      'SELECT COUNT(id), AVG(salary) FROM test.Employee WHERE department = ? AND (age > ? OR yearsOfService >= ?) GROUP BY department, age;'
+      'SELECT COUNT(`id`), AVG(`salary`) FROM `test`.`Employee` WHERE `department` = ? AND (`age` > ? OR `yearsOfService` >= ?) GROUP BY `department`, `age`;'
     );
     expect(result.params).toEqual(['Engineering', 50, 20]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
     expect(result.sql).toContain(
-      'SELECT COUNT(id), AVG(salary) FROM test.Employee WHERE department = @param0 AND (age > @param1 OR yearsOfService >= @param2) GROUP BY department, age;'
+      'SELECT COUNT(`id`), AVG(`salary`) FROM `test`.`Employee` WHERE `department` = @param0 AND (`age` > @param1 OR `yearsOfService` >= @param2) GROUP BY `department`, `age`;'
     );
     expect(result.namedParams?.params).toEqual({ param0: 'Engineering', param1: 50, param2: 20 });
     expect(result.namedParams?.types).toEqual({ param0: 'string', param1: 'number', param2: 'number' });

--- a/packages/query/test/LogicalOperators.test.ts
+++ b/packages/query/test/LogicalOperators.test.ts
@@ -48,20 +48,20 @@ describe('QueryBuilder - Logical Operator Support', () => {
 
     // Standard SQL output
     expect(qb.toSql({ dbName }).sql).toBe(
-      "SELECT MAX(age) FROM test.Employee WHERE (((department = 'Engineering' AND name LIKE '%John%') OR department = 'Product') AND (age > 30 AND age < 50) AND (salary > 50000 OR salary <= 100000)) GROUP BY department;"
+      "SELECT MAX(`age`) FROM `test`.`Employee` WHERE (((`department` = 'Engineering' AND `name` LIKE '%John%') OR `department` = 'Product') AND (`age` > 30 AND `age` < 50) AND (`salary` > 50000 OR `salary` <= 100000)) GROUP BY `department`;"
     );
 
     // SQL output with positional parameters
     let result = qb.toSql({ dbName, useParams: true });
     expect(result.sql).toBe(
-      'SELECT MAX(age) FROM test.Employee WHERE (((department = ? AND name LIKE ?) OR department = ?) AND (age > ? AND age < ?) AND (salary > ? OR salary <= ?)) GROUP BY department;'
+      'SELECT MAX(`age`) FROM `test`.`Employee` WHERE (((`department` = ? AND `name` LIKE ?) OR `department` = ?) AND (`age` > ? AND `age` < ?) AND (`salary` > ? OR `salary` <= ?)) GROUP BY `department`;'
     );
     expect(result.params).toEqual(['Engineering', '%John%', 'Product', 30, 50, 50000, 100000]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
     expect(result.sql).toBe(
-      'SELECT MAX(age) FROM test.Employee WHERE (((department = @param0 AND name LIKE @param1) OR department = @param2) AND (age > @param3 AND age < @param4) AND (salary > @param5 OR salary <= @param6)) GROUP BY department;'
+      'SELECT MAX(`age`) FROM `test`.`Employee` WHERE (((`department` = @param0 AND `name` LIKE @param1) OR `department` = @param2) AND (`age` > @param3 AND `age` < @param4) AND (`salary` > @param5 OR `salary` <= @param6)) GROUP BY `department`;'
     );
     expect(result.namedParams?.params).toEqual({
       param0: 'Engineering',
@@ -108,20 +108,20 @@ describe('QueryBuilder - Logical Operator Support', () => {
     // Standard SQL output
     let result = qb.toSql({ dbName });
     expect(result.sql).toBe(
-      "SELECT MAX(age) FROM test.Employee WHERE (((department = 'Engineering' AND name LIKE '%John%') OR department = 'Product') AND (age > 30 AND age < 50) AND (salary > 50000 OR salary <= 100000)) GROUP BY department;"
+      "SELECT MAX(`age`) FROM `test`.`Employee` WHERE (((`department` = 'Engineering' AND `name` LIKE '%John%') OR `department` = 'Product') AND (`age` > 30 AND `age` < 50) AND (`salary` > 50000 OR `salary` <= 100000)) GROUP BY `department`;"
     );
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
     expect(result.sql).toBe(
-      'SELECT MAX(age) FROM test.Employee WHERE (((department = ? AND name LIKE ?) OR department = ?) AND (age > ? AND age < ?) AND (salary > ? OR salary <= ?)) GROUP BY department;'
+      'SELECT MAX(`age`) FROM `test`.`Employee` WHERE (((`department` = ? AND `name` LIKE ?) OR `department` = ?) AND (`age` > ? AND `age` < ?) AND (`salary` > ? OR `salary` <= ?)) GROUP BY `department`;'
     );
     expect(result.params).toEqual(['Engineering', '%John%', 'Product', 30, 50, 50000, 100000]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
     expect(result.sql).toBe(
-      'SELECT MAX(age) FROM test.Employee WHERE (((department = @param0 AND name LIKE @param1) OR department = @param2) AND (age > @param3 AND age < @param4) AND (salary > @param5 OR salary <= @param6)) GROUP BY department;'
+      'SELECT MAX(`age`) FROM `test`.`Employee` WHERE (((`department` = @param0 AND `name` LIKE @param1) OR `department` = @param2) AND (`age` > @param3 AND `age` < @param4) AND (`salary` > @param5 OR `salary` <= @param6)) GROUP BY `department`;'
     );
     expect(result.namedParams?.params).toEqual({
       param0: 'Engineering',
@@ -168,20 +168,20 @@ describe('QueryBuilder - Logical Operator Support', () => {
     // Standard SQL output
     let result = qb.toSql({ dbName });
     expect(result.sql).toBe(
-      "SELECT MAX(age) FROM test.Employee WHERE (((department = 'Engineering' AND name LIKE '%John%') OR department = 'Product') AND (age > 30 AND age < 50) AND (salary > 50000 OR salary <= 100000)) GROUP BY department;"
+      "SELECT MAX(`age`) FROM `test`.`Employee` WHERE (((`department` = 'Engineering' AND `name` LIKE '%John%') OR `department` = 'Product') AND (`age` > 30 AND `age` < 50) AND (`salary` > 50000 OR `salary` <= 100000)) GROUP BY `department`;"
     );
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
     expect(result.sql).toBe(
-      'SELECT MAX(age) FROM test.Employee WHERE (((department = ? AND name LIKE ?) OR department = ?) AND (age > ? AND age < ?) AND (salary > ? OR salary <= ?)) GROUP BY department;'
+      'SELECT MAX(`age`) FROM `test`.`Employee` WHERE (((`department` = ? AND `name` LIKE ?) OR `department` = ?) AND (`age` > ? AND `age` < ?) AND (`salary` > ? OR `salary` <= ?)) GROUP BY `department`;'
     );
     expect(result.params).toEqual(['Engineering', '%John%', 'Product', 30, 50, 50000, 100000]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
     expect(result.sql).toBe(
-      'SELECT MAX(age) FROM test.Employee WHERE (((department = @param0 AND name LIKE @param1) OR department = @param2) AND (age > @param3 AND age < @param4) AND (salary > @param5 OR salary <= @param6)) GROUP BY department;'
+      'SELECT MAX(`age`) FROM `test`.`Employee` WHERE (((`department` = @param0 AND `name` LIKE @param1) OR `department` = @param2) AND (`age` > @param3 AND `age` < @param4) AND (`salary` > @param5 OR `salary` <= @param6)) GROUP BY `department`;'
     );
     expect(result.namedParams?.params).toEqual({
       param0: 'Engineering',

--- a/packages/query/test/Pagination.test.ts
+++ b/packages/query/test/Pagination.test.ts
@@ -18,16 +18,16 @@ describe('QueryBuilder - Pagination Support', () => {
 
     // Standard SQL output with pagination
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe("SELECT * FROM test.Employee WHERE country = 'USA' LIMIT 10 OFFSET 10;");
+    expect(result.sql).toBe("SELECT * FROM `test`.`Employee` WHERE `country` = 'USA' LIMIT 10 OFFSET 10;");
 
     // SQL output with positional parameters including pagination
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE country = ? LIMIT 10 OFFSET 10;');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `country` = ? LIMIT 10 OFFSET 10;');
     expect(result.params).toEqual(['USA']);
 
     // SQL output with named parameters and types including pagination
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE country = @param0 LIMIT 10 OFFSET 10;');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `country` = @param0 LIMIT 10 OFFSET 10;');
     expect(result.namedParams?.params).toEqual({ param0: 'USA' });
     expect(result.namedParams?.types).toEqual({ param0: 'string' });
   });

--- a/packages/query/test/QueryBuilder.test.ts
+++ b/packages/query/test/QueryBuilder.test.ts
@@ -21,17 +21,17 @@ describe('QueryBuilder - Factory tests', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    const expectedSQL = "SELECT * FROM test.Employee WHERE name = 'John Doe' AND country = 'USA';";
+    const expectedSQL = "SELECT * FROM `test`.`Employee` WHERE `name` = 'John Doe' AND `country` = 'USA';";
     expect(result.sql).toBe(expectedSQL);
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE name = ? AND country = ?;');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `name` = ? AND `country` = ?;');
     expect(result.params).toEqual(['John Doe', 'USA']);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE name = @param0 AND country = @param1;');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `name` = @param0 AND `country` = @param1;');
     expect(result.namedParams?.params).toEqual({ param0: 'John Doe', param1: 'USA' });
     expect(result.namedParams?.types).toEqual({ param0: 'string', param1: 'string' });
   });

--- a/packages/query/test/ResolveFieldName.test.ts
+++ b/packages/query/test/ResolveFieldName.test.ts
@@ -52,20 +52,20 @@ describe('QueryBuilder - Resolve Field Name Support', () => {
 
     // Standard SQL output
     expect(qb.toSql({ dbName, resolveFieldName }).sql).toBe(
-      "SELECT MAX(employee_age) FROM test.Employee WHERE (((department = 'Engineering' AND employee_name LIKE '%John%') OR department = 'Product') AND (employee_age > 30 AND employee_age < 50) AND (employee_salary > 50000 OR employee_salary <= 100000)) GROUP BY employee_age;"
+      "SELECT MAX(`employee_age`) FROM `test`.`Employee` WHERE (((`department` = 'Engineering' AND `employee_name` LIKE '%John%') OR `department` = 'Product') AND (`employee_age` > 30 AND `employee_age` < 50) AND (`employee_salary` > 50000 OR `employee_salary` <= 100000)) GROUP BY `employee_age`;"
     );
 
     // SQL output with positional parameters
     let result = qb.toSql({ dbName, resolveFieldName, useParams: true });
     expect(result.sql).toBe(
-      'SELECT MAX(employee_age) FROM test.Employee WHERE (((department = ? AND employee_name LIKE ?) OR department = ?) AND (employee_age > ? AND employee_age < ?) AND (employee_salary > ? OR employee_salary <= ?)) GROUP BY employee_age;'
+      'SELECT MAX(`employee_age`) FROM `test`.`Employee` WHERE (((`department` = ? AND `employee_name` LIKE ?) OR `department` = ?) AND (`employee_age` > ? AND `employee_age` < ?) AND (`employee_salary` > ? OR `employee_salary` <= ?)) GROUP BY `employee_age`;'
     );
     expect(result.params).toEqual(['Engineering', '%John%', 'Product', 30, 50, 50000, 100000]);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, resolveFieldName, useParams: true, useNamedParams: true });
     expect(result.sql).toBe(
-      'SELECT MAX(employee_age) FROM test.Employee WHERE (((department = @param0 AND employee_name LIKE @param1) OR department = @param2) AND (employee_age > @param3 AND employee_age < @param4) AND (employee_salary > @param5 OR employee_salary <= @param6)) GROUP BY employee_age;'
+      'SELECT MAX(`employee_age`) FROM `test`.`Employee` WHERE (((`department` = @param0 AND `employee_name` LIKE @param1) OR `department` = @param2) AND (`employee_age` > @param3 AND `employee_age` < @param4) AND (`employee_salary` > @param5 OR `employee_salary` <= @param6)) GROUP BY `employee_age`;'
     );
     expect(result.namedParams?.params).toEqual({
       param0: 'Engineering',

--- a/packages/query/test/Select.test.ts
+++ b/packages/query/test/Select.test.ts
@@ -21,17 +21,17 @@ describe('QueryBuilder - Select tests', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    const expectedSQL = "SELECT * FROM test.Employee WHERE name = 'John Doe' AND country = 'USA';";
+    const expectedSQL = "SELECT * FROM `test`.`Employee` WHERE `name` = 'John Doe' AND `country` = 'USA';";
     expect(result.sql).toBe(expectedSQL);
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE name = ? AND country = ?;');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `name` = ? AND `country` = ?;');
     expect(result.params).toEqual(['John Doe', 'USA']);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE name = @param0 AND country = @param1;');
+    expect(result.sql).toContain('SELECT * FROM `test`.`Employee` WHERE `name` = @param0 AND `country` = @param1;');
     expect(result.namedParams?.params).toEqual({ param0: 'John Doe', param1: 'USA' });
     expect(result.namedParams?.types).toEqual({ param0: 'string', param1: 'string' });
   });
@@ -46,17 +46,19 @@ describe('QueryBuilder - Select tests', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    const expectedSQL = "SELECT name, age FROM test.Employee WHERE name = 'John Doe' AND country = 'USA';";
+    const expectedSQL = "SELECT `name`, `age` FROM `test`.`Employee` WHERE `name` = 'John Doe' AND `country` = 'USA';";
     expect(result.sql).toBe(expectedSQL);
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toContain('SELECT name, age FROM test.Employee WHERE name = ? AND country = ?;');
+    expect(result.sql).toContain('SELECT `name`, `age` FROM `test`.`Employee` WHERE `name` = ? AND `country` = ?;');
     expect(result.params).toEqual(['John Doe', 'USA']);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('SELECT name, age FROM test.Employee WHERE name = @param0 AND country = @param1;');
+    expect(result.sql).toContain(
+      'SELECT `name`, `age` FROM `test`.`Employee` WHERE `name` = @param0 AND `country` = @param1;'
+    );
     expect(result.namedParams?.params).toEqual({ param0: 'John Doe', param1: 'USA' });
     expect(result.namedParams?.types).toEqual({ param0: 'string', param1: 'string' });
   });
@@ -66,16 +68,16 @@ describe('QueryBuilder - Select tests', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName: 'INFORMATION_SCHEMA' });
-    expect(result.sql).toBe("SELECT * FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_NAME = 'Employee';");
+    expect(result.sql).toBe("SELECT * FROM `INFORMATION_SCHEMA`.`STATISTICS` WHERE `TABLE_NAME` = 'Employee';");
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName: 'INFORMATION_SCHEMA', useParams: true });
-    expect(result.sql).toContain('SELECT * FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_NAME = ?;');
+    expect(result.sql).toContain('SELECT * FROM `INFORMATION_SCHEMA`.`STATISTICS` WHERE `TABLE_NAME` = ?;');
     expect(result.params).toEqual(['Employee']);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName: 'INFORMATION_SCHEMA', useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('SELECT * FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_NAME = @param0;');
+    expect(result.sql).toContain('SELECT * FROM `INFORMATION_SCHEMA`.`STATISTICS` WHERE `TABLE_NAME` = @param0;');
     expect(result.namedParams?.params).toEqual({ param0: 'Employee' });
     expect(result.namedParams?.types).toEqual({ param0: 'string' });
   });

--- a/packages/query/test/Sorting.test.ts
+++ b/packages/query/test/Sorting.test.ts
@@ -19,16 +19,20 @@ describe('QueryBuilder - Sorting Support', () => {
 
     // Standard SQL output
     let result = qb.toSql({ dbName });
-    expect(result.sql).toBe("SELECT * FROM test.Employee WHERE country = 'USA' ORDER BY age DESC, name ASC;");
+    expect(result.sql).toBe("SELECT * FROM `test`.`Employee` WHERE `country` = 'USA' ORDER BY `age` DESC, `name` ASC;");
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE country = ? ORDER BY age DESC, name ASC;');
+    expect(result.sql).toContain(
+      'SELECT * FROM `test`.`Employee` WHERE `country` = ? ORDER BY `age` DESC, `name` ASC;'
+    );
     expect(result.params).toEqual(['USA']);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('SELECT * FROM test.Employee WHERE country = @param0 ORDER BY age DESC, name ASC;');
+    expect(result.sql).toContain(
+      'SELECT * FROM `test`.`Employee` WHERE `country` = @param0 ORDER BY `age` DESC, `name` ASC;'
+    );
     expect(result.namedParams?.params).toEqual({ param0: 'USA' });
     expect(result.namedParams?.types).toEqual({ param0: 'string' });
   });
@@ -41,20 +45,20 @@ describe('QueryBuilder - Sorting Support', () => {
     // Standard SQL output
     let result = qb.toSql({ dbName });
     expect(result.sql).toBe(
-      "SELECT * FROM test.Employee WHERE country = 'USA' ORDER BY CASE WHEN name = 'John' THEN 0 WHEN name = 'Doe' THEN 1 WHEN name = 'Smith' THEN 2 ELSE 3 END ASC;"
+      "SELECT * FROM `test`.`Employee` WHERE `country` = 'USA' ORDER BY CASE WHEN `name` = 'John' THEN 0 WHEN `name` = 'Doe' THEN 1 WHEN `name` = 'Smith' THEN 2 ELSE 3 END ASC;"
     );
 
     // SQL output with positional parameters
     result = qb.toSql({ dbName, useParams: true });
     expect(result.sql).toContain(
-      'SELECT * FROM test.Employee WHERE country = ? ORDER BY CASE WHEN name = ? THEN 0 WHEN name = ? THEN 1 WHEN name = ? THEN 2 ELSE 3 END ASC;'
+      'SELECT * FROM `test`.`Employee` WHERE `country` = ? ORDER BY CASE WHEN `name` = ? THEN 0 WHEN `name` = ? THEN 1 WHEN `name` = ? THEN 2 ELSE 3 END ASC;'
     );
     expect(result.params).toEqual(['USA', 'John', 'Doe', 'Smith']);
 
     // SQL output with named parameters and types
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
     expect(result.sql).toContain(
-      'SELECT * FROM test.Employee WHERE country = @param0 ORDER BY CASE WHEN name = @param1 THEN 0 WHEN name = @param2 THEN 1 WHEN name = @param3 THEN 2 ELSE 3 END ASC;'
+      'SELECT * FROM `test`.`Employee` WHERE `country` = @param0 ORDER BY CASE WHEN `name` = @param1 THEN 0 WHEN `name` = @param2 THEN 1 WHEN `name` = @param3 THEN 2 ELSE 3 END ASC;'
     );
     expect(result.namedParams?.params).toEqual({ param0: 'USA', param1: 'John', param2: 'Doe', param3: 'Smith' });
     expect(result.namedParams?.types).toEqual({

--- a/packages/query/test/StatementFactory.test.ts
+++ b/packages/query/test/StatementFactory.test.ts
@@ -18,16 +18,18 @@ describe('StatementFactory', () => {
 
     // Standard SQL output without parameterization
     let result = factory.insert(tableName, data, { dbName });
-    expect(result.sql).toBe("INSERT INTO test.Employee (name, age, country) VALUES ('John Doe', 30, 'USA');");
+    expect(result.sql).toBe("INSERT INTO `test`.`Employee` (`name`, `age`, `country`) VALUES ('John Doe', 30, 'USA');");
 
     // SQL output with positional parameters
     result = factory.insert(tableName, data, { dbName, useParams: true });
-    expect(result.sql).toContain('INSERT INTO test.Employee (name, age, country) VALUES (?, ?, ?);');
+    expect(result.sql).toContain('INSERT INTO `test`.`Employee` (`name`, `age`, `country`) VALUES (?, ?, ?);');
     expect(result.params).toEqual(['John Doe', 30, 'USA']);
 
     // SQL output with named parameters
     result = factory.insert(tableName, data, { dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('INSERT INTO test.Employee (name, age, country) VALUES (@param0, @param1, @param2);');
+    expect(result.sql).toContain(
+      'INSERT INTO `test`.`Employee` (`name`, `age`, `country`) VALUES (@param0, @param1, @param2);'
+    );
     expect(result.namedParams?.params).toEqual({ param0: 'John Doe', param1: 30, param2: 'USA' });
     expect(result.namedParams?.types).toEqual({ param0: 'string', param1: 'number', param2: 'string' });
   });
@@ -43,16 +45,16 @@ describe('StatementFactory', () => {
 
     // Standard SQL output without parameterization
     let result = factory.update(tableName, data, queryBuilder, { dbName });
-    expect(result.sql).toBe("UPDATE test.Employee SET age = 31 WHERE name = 'John Doe';");
+    expect(result.sql).toBe("UPDATE `test`.`Employee` SET `age` = 31 WHERE `name` = 'John Doe';");
 
     // SQL output with positional parameters
     result = factory.update(tableName, data, queryBuilder, { dbName, useParams: true });
-    expect(result.sql).toContain('UPDATE test.Employee SET age = ? WHERE name = ?;');
+    expect(result.sql).toContain('UPDATE `test`.`Employee` SET `age` = ? WHERE `name` = ?;');
     expect(result.params).toEqual([31, 'John Doe']);
 
     // SQL output with named parameters
     result = factory.update(tableName, data, queryBuilder, { dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('UPDATE test.Employee SET age = @param0 WHERE name = @param1;');
+    expect(result.sql).toContain('UPDATE `test`.`Employee` SET `age` = @param0 WHERE `name` = @param1;');
     expect(result.namedParams?.params).toEqual({ param0: 31, param1: 'John Doe' });
     expect(result.namedParams?.types).toEqual({ param0: 'number', param1: 'string' });
   });
@@ -67,16 +69,16 @@ describe('StatementFactory', () => {
 
     // Standard SQL output without parameterization
     let result = factory.delete(tableName, queryBuilder, { dbName });
-    expect(result.sql).toBe("DELETE FROM test.Employee WHERE country = 'USA';");
+    expect(result.sql).toBe("DELETE FROM `test`.`Employee` WHERE `country` = 'USA';");
 
     // SQL output with positional parameters
     result = factory.delete(tableName, queryBuilder, { dbName, useParams: true });
-    expect(result.sql).toContain('DELETE FROM test.Employee WHERE country = ?;');
+    expect(result.sql).toContain('DELETE FROM `test`.`Employee` WHERE `country` = ?;');
     expect(result.params).toEqual(['USA']);
 
     // SQL output with named parameters
     result = factory.delete(tableName, queryBuilder, { dbName, useParams: true, useNamedParams: true });
-    expect(result.sql).toContain('DELETE FROM test.Employee WHERE country = @param0;');
+    expect(result.sql).toContain('DELETE FROM `test`.`Employee` WHERE `country` = @param0;');
     expect(result.namedParams?.params).toEqual({ param0: 'USA' });
     expect(result.namedParams?.types).toEqual({ param0: 'string' });
   });

--- a/packages/query/test/SubQueries.test.ts
+++ b/packages/query/test/SubQueries.test.ts
@@ -27,20 +27,20 @@ describe('QueryBuilder - Sub Query Support', () => {
     // Standard SQL output for subquery
     let result = qb.toSql({ dbName });
     expect(result.sql).toBe(
-      "SELECT * FROM test.Employee WHERE id IN (SELECT * FROM test.Employee WHERE department = 'Engineering');"
+      "SELECT * FROM `test`.`Employee` WHERE `id` IN (SELECT * FROM `test`.`Employee` WHERE `department` = 'Engineering');"
     );
 
     // SQL output with positional parameters for subquery
     result = qb.toSql({ dbName, useParams: true });
     expect(result.sql).toContain(
-      'SELECT * FROM test.Employee WHERE id IN (SELECT * FROM test.Employee WHERE department = ?);'
+      'SELECT * FROM `test`.`Employee` WHERE `id` IN (SELECT * FROM `test`.`Employee` WHERE `department` = ?);'
     );
     expect(result.params).toEqual(['Engineering']);
 
     // SQL output with named parameters and types for subquery
     result = qb.toSql({ dbName, useParams: true, useNamedParams: true });
     expect(result.sql).toContain(
-      'SELECT * FROM test.Employee WHERE id IN (SELECT * FROM test.Employee WHERE department = @param0);'
+      'SELECT * FROM `test`.`Employee` WHERE `id` IN (SELECT * FROM `test`.`Employee` WHERE `department` = @param0);'
     );
     expect(result.namedParams?.params).toEqual({ param0: 'Engineering' });
     expect(result.namedParams?.types).toEqual({ param0: 'string' });
@@ -79,13 +79,14 @@ describe('QueryBuilder - Sub Query Support', () => {
 
     // Standard SQL output for the main query
     let result = mainQuery.toSql({ dbName });
-    const expectedSql = `SELECT * FROM test.Employee WHERE (department = 'Engineering' OR (salary > 50000 AND (yearsOfExperience <= 3 OR id IN (SELECT * FROM test.Employee WHERE (department = 'HR' AND yearsOfExperience > 5 AND salary < 60000) AND (department = 'IT' OR salary >= 80000)))));`;
+    const expectedSql =
+      "SELECT * FROM `test`.`Employee` WHERE (`department` = 'Engineering' OR (`salary` > 50000 AND (`yearsOfExperience` <= 3 OR `id` IN (SELECT * FROM `test`.`Employee` WHERE (`department` = 'HR' AND `yearsOfExperience` > 5 AND `salary` < 60000) AND (`department` = 'IT' OR `salary` >= 80000)))));";
     expect(result.sql).toBe(expectedSql);
 
     // SQL output with positional parameters
     result = mainQuery.toSql({ dbName, useParams: true });
     expect(result.sql).toContain(
-      `SELECT * FROM test.Employee WHERE (department = ? OR (salary > ? AND (yearsOfExperience <= ? OR id IN (SELECT * FROM test.Employee WHERE (department = ? AND yearsOfExperience > ? AND salary < ?) AND (department = ? OR salary >= ?)))));`
+      'SELECT * FROM `test`.`Employee` WHERE (`department` = ? OR (`salary` > ? AND (`yearsOfExperience` <= ? OR `id` IN (SELECT * FROM `test`.`Employee` WHERE (`department` = ? AND `yearsOfExperience` > ? AND `salary` < ?) AND (`department` = ? OR `salary` >= ?)))));'
     );
     expect(result.params).toEqual(['Engineering', 50000, 3, 'HR', 5, 60000, 'IT', 80000]);
 
@@ -102,7 +103,7 @@ describe('QueryBuilder - Sub Query Support', () => {
       param7: 80000,
     };
     expect(result.sql).toContain(
-      `SELECT * FROM test.Employee WHERE (department = @param0 OR (salary > @param1 AND (yearsOfExperience <= @param2 OR id IN (SELECT * FROM test.Employee WHERE (department = @param0 AND yearsOfExperience > @param1 AND salary < @param2) AND (department = @param3 OR salary >= @param4)))));`
+      'SELECT * FROM `test`.`Employee` WHERE (`department` = @param0 OR (`salary` > @param1 AND (`yearsOfExperience` <= @param2 OR `id` IN (SELECT * FROM `test`.`Employee` WHERE (`department` = @param0 AND `yearsOfExperience` > @param1 AND `salary` < @param2) AND (`department` = @param3 OR `salary` >= @param4)))));'
     );
     expect(result.namedParams?.params).toEqual(expectedParams);
     expect(result.namedParams?.types).toEqual({


### PR DESCRIPTION
This allows you to define column or table names that would otherwise conflict with reserved words in the db engine (ie. having a column named `order`).

Added integration tests to `CrudTests` to test reserved word support. Also updated all tests in db-query to support the new expected sql output.