### PR TITLE
feat: enhance TableWatcher API with query mutation capabilities

### DIFF
--- a/packages/db/src/Db.ts
+++ b/packages/db/src/Db.ts
@@ -205,10 +205,10 @@ export class Db<R extends Record = Record> implements DbService<R> {
     const generateDelete = (config: DbDriverDmlStatementConfig) =>
       new StatementFactory<T>().delete(table.name, deleteQb, this.statementConfigFactory.getStatementConfig(config));
     await this.runColumnBeforeDeletes(table, recordsToDelete);
-    await this.tableWatcherRunner.runBeforeDeleteTableWatchers(table, recordsToDelete, qb);
+    await this.tableWatcherRunner.runBeforeDeleteTableWatchers(table, recordsToDelete, qb, deleteQb);
     const recordDeleteCount = await this.dbDriver.runDml(generateDelete, this.currentTransaction);
     await this.runCascadeDeletions(table, recordsToDeleteIds);
-    await this.tableWatcherRunner.runAfterDeleteTableWatchers(table, recordDeleteCount, recordsToDelete, qb);
+    await this.tableWatcherRunner.runAfterDeleteTableWatchers(table, recordDeleteCount, recordsToDelete, qb, deleteQb);
     return recordDeleteCount;
   }
 

--- a/packages/db/src/TableWatcher.ts
+++ b/packages/db/src/TableWatcher.ts
@@ -72,6 +72,15 @@ export interface TableWatcher<R extends Record = Record> extends Loadable {
   afterInsert?<T extends R>(record: T): Promise<void>;
   beforeUpdate?<T extends R>(record: Partial<T>, qb: QueryBuilder<T>): Promise<Partial<T>>;
   afterUpdate?<T extends R>(recordUpdateCount: number, record: Partial<T>, qb: QueryBuilder<T>): Promise<void>;
-  beforeDelete?<T extends R>(recordsToDelete: T[], qb: QueryBuilder<T>): Promise<void>;
-  afterDelete?<T extends R>(recordDeleteCount: number, deletedRecords: T[], qb: QueryBuilder<T>): Promise<void>;
+  beforeDelete?<T extends R>(
+    recordsToDelete: T[],
+    initialQb: QueryBuilder<T>,
+    deleteQb: QueryBuilder<T>
+  ): Promise<void>;
+  afterDelete?<T extends R>(
+    recordDeleteCount: number,
+    deletedRecords: T[],
+    initialQb: QueryBuilder<T>,
+    deleteQb: QueryBuilder<T>
+  ): Promise<void>;
 }

--- a/packages/db/src/TableWatcherRunner.ts
+++ b/packages/db/src/TableWatcherRunner.ts
@@ -117,7 +117,8 @@ export class TableWatcherRunner<R extends Record = Record> {
   async runBeforeDeleteTableWatchers<T extends R>(
     table: Table<T>,
     recordsToDelete: T[],
-    qb: QueryBuilder<T>
+    initialQb: QueryBuilder<T>,
+    deleteQb: QueryBuilder<T>
   ): Promise<void> {
     const tableWatcherMap = TableWatcherRunner.tableWatcherMap[table.name];
     if (!tableWatcherMap) {
@@ -130,10 +131,10 @@ export class TableWatcherRunner<R extends Record = Record> {
     }
 
     this.logger.info({ message: `(${table.name}) Running before-delete table watchers` });
-    const qbCopy = QueryBuilder.fromQueryBuilder(qb, table.name);
+    const initialQbCopy = QueryBuilder.fromQueryBuilder(initialQb, table.name);
     for (const tableWatcher of tableWatchers) {
       this.logger.info({ message: `(${table.name}) Running ${tableWatcher.name()}.beforeDelete` });
-      await tableWatcher.beforeDelete(recordsToDelete, qbCopy);
+      await tableWatcher.beforeDelete(recordsToDelete, initialQbCopy, deleteQb);
       this.logger.info({ message: `(${table.name}) Finished running ${tableWatcher.name()}.beforeDelete` });
     }
     this.logger.info({ message: `(${table.name}) Finished running before-delete table watchers` });
@@ -143,7 +144,8 @@ export class TableWatcherRunner<R extends Record = Record> {
     table: Table<T>,
     recordDeleteCount: number,
     deletedRecords: T[],
-    qb: QueryBuilder<T>
+    initialQb: QueryBuilder<T>,
+    deleteQb: QueryBuilder<T>
   ): Promise<void> {
     const tableWatcherMap = TableWatcherRunner.tableWatcherMap[table.name];
     if (!tableWatcherMap) {
@@ -156,10 +158,10 @@ export class TableWatcherRunner<R extends Record = Record> {
     }
 
     this.logger.info({ message: `(${table.name}) Running after-delete table watchers` });
-    const qbCopy = QueryBuilder.fromQueryBuilder(qb, table.name);
+    const initialQbCopy = QueryBuilder.fromQueryBuilder(initialQb, table.name);
     for (const tableWatcher of tableWatchers) {
       this.logger.info({ message: `(${table.name}) Running ${tableWatcher.name()}.afterDelete` });
-      await tableWatcher.afterDelete(recordDeleteCount, deletedRecords, qbCopy);
+      await tableWatcher.afterDelete(recordDeleteCount, deletedRecords, initialQbCopy, deleteQb);
       this.logger.info({ message: `(${table.name}) Finished running ${tableWatcher.name()}.afterDelete` });
     }
     this.logger.info({ message: `(${table.name}) Finished running after-delete table watchers` });

--- a/packages/file-storage-drivers/google-cloud-storage/src/GoogleCloudStorageTableWatcher.ts
+++ b/packages/file-storage-drivers/google-cloud-storage/src/GoogleCloudStorageTableWatcher.ts
@@ -37,7 +37,11 @@ export class GoogleCloudStorageTableWatcher implements TableWatcher<File> {
     return new FileTable();
   }
 
-  async beforeDelete<T extends File>(recordsToDelete: T[], qb: QueryBuilder<T>): Promise<void> {
+  async beforeDelete<T extends File>(
+    recordsToDelete: T[],
+    initialQb: QueryBuilder<T>,
+    deleteQb: QueryBuilder<T>
+  ): Promise<void> {
     const fileIdsToDelete = recordsToDelete.map((record) => record.id);
     for (const fileId of fileIdsToDelete) {
       const file = this.storage.bucket(this.bucketName).file(fileId);


### PR DESCRIPTION
- Add initialQb and deleteQb parameters to beforeDelete/afterDelete methods
- Enable query inspection and mutation in TableWatcher callbacks
- Update TableWatcherRunner to pass new parameters
- Update Db.delete to provide both initial and mutable query builders
- Update all TableWatcher implementations with new signatures